### PR TITLE
Making selector levels as small as possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ This:
 ```
 Will converts to:
 ```css
-html[dir] .foo {
+.foo {
     border-color: lightgray;
 }
 
-html[dir="ltr"] .foo {
+[dir="ltr"] .foo {
     float: right;
     margin-left: 13px;
     text-align: right;
@@ -63,7 +63,7 @@ html[dir="ltr"] .foo {
     animation: 1s slide-ltr 0s ease-in-out
 }
 
-html[dir="rtl"] .foo {
+[dir="rtl"] .foo {
     float: left;
     margin-right: 13px;
     text-align: left;

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -16,18 +16,21 @@ const addDirToSelectors = ( selectors = '', dir ) => {
             prefix = `[dir="${ dir }"]`
             break
         default:
-            prefix = '[dir]'
+            // use empty prefix for least change of the priority level
+            prefix = ''
     }
 
     selectors = selectors
         .split( /\s*,\s*/ )
         .map( selector => {
             if ( isHtmlSelector( selector ) ) {
-                selector = selector.replace( /html/ig, `html${ prefix }` )
+                // replace `html` at the beginning of selector 
+                selector = selector.replace( /^html/ig, `html${ prefix }` )
             } else if ( isRootSelector( selector ) ) {
                 selector = selector.replace( /:root/ig, `${ prefix }:root` )
             } else {
-                selector = `html${ prefix } ${ selector }`
+                // just add prefix for least change of the priority level
+                selector = prefix ? `${ prefix } ${ selector }` : selector
             }
             return selector
         } )

--- a/test.js
+++ b/test.js
@@ -11,9 +11,9 @@ const run = ( t, input, output, opts = {} ) =>
         } )
 
 
-test( 'Added html[dir] prefix to symmetric rules', t => run( t,
+test( 'do NOT Add [dir] prefix to symmetric rules', t => run( t,
     'a { text-align: center }',
-    '[dir] a { text-align: center }'
+    'a { text-align: center }'
 ) )
 
 test( 'Creates both LTR & RTL rules for asymmetric declarations', t => run( t,

--- a/test.js
+++ b/test.js
@@ -13,18 +13,18 @@ const run = ( t, input, output, opts = {} ) =>
 
 test( 'Added html[dir] prefix to symmetric rules', t => run( t,
     'a { text-align: center }',
-    'html[dir] a { text-align: center }'
+    '[dir] a { text-align: center }'
 ) )
 
 test( 'Creates both LTR & RTL rules for asymmetric declarations', t => run( t,
     'a { text-align: left }',
-    'html[dir="ltr"] a { text-align: left } ' +
-    'html[dir="rtl"] a { text-align: right }'
+    '[dir="ltr"] a { text-align: left } ' +
+    '[dir="rtl"] a { text-align: right }'
 ) )
 
 test( 'Removes original rule without symmetric declarations', t => run( t,
     'a { text-align: left }',
-    'html[dir="ltr"] a { text-align: left } ' +
-    'html[dir="rtl"] a { text-align: right }'
+    '[dir="ltr"] a { text-align: left } ' +
+    '[dir="rtl"] a { text-align: right }'
 ) )
 


### PR DESCRIPTION
It's better for making selector levels as small as possible.

CHANGES:

- should NOT add `html` to dir prefix
- should NOT add `[dir]` to symmetric rules