### PR TITLE
Making selector levels as small as possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,15 @@ This:
     float: right;
     margin-left: 13px;
     text-align: right;
+    font-size: 13px;
     border-color: lightgray;
     border-width: 2px 0 2px 2px;
     border-style: solid dashed solid solid;
     animation: 1s slide 0s ease-in-out
 }
-
+.foo {
+    text-align: center;
+}
 @keyframes slide {
     from {
         transform: translate( -1000px )
@@ -50,11 +53,13 @@ This:
 ```
 Will converts to:
 ```css
-html[dir] .foo {
-    border-color: lightgray;
+.foo {
+    font-size: 13px
 }
-
-html[dir="ltr"] .foo {
+[dir] .foo {
+    border-color: lightgray
+}
+[dir="ltr"] .foo {
     float: right;
     margin-left: 13px;
     text-align: right;
@@ -62,8 +67,7 @@ html[dir="ltr"] .foo {
     border-style: solid dashed solid solid;
     animation: 1s slide-ltr 0s ease-in-out
 }
-
-html[dir="rtl"] .foo {
+[dir="rtl"] .foo {
     float: left;
     margin-right: 13px;
     text-align: left;
@@ -71,7 +75,9 @@ html[dir="rtl"] .foo {
     border-style: solid solid solid dashed;
     animation: 1s slide-rtl 0s ease-in-out
 }
-
+[dir] .foo {
+    text-align: center
+}
 @keyframes slide-ltr {
     from {
         transform: translate( -1000px )
@@ -80,7 +86,6 @@ html[dir="rtl"] .foo {
         transform: translate( 0 )
     }
 }
-
 @keyframes slide-rtl {
     from {
         transform: translate( 1000px )

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -15,19 +15,24 @@ const addDirToSelectors = ( selectors = '', dir ) => {
         case 'rtl':
             prefix = `[dir="${ dir }"]`
             break
-        default:
+        case 'dir':
             prefix = '[dir]'
+            break
+        default:
+            prefix = ''
     }
 
     selectors = selectors
         .split( /\s*,\s*/ )
         .map( selector => {
             if ( isHtmlSelector( selector ) ) {
-                selector = selector.replace( /html/ig, `html${ prefix }` )
+                // only replace `html` at the beginning of selector
+                selector = selector.replace( /^html/ig, `html${ prefix }` )
             } else if ( isRootSelector( selector ) ) {
                 selector = selector.replace( /:root/ig, `${ prefix }:root` )
-            } else {
-                selector = `html${ prefix } ${ selector }`
+            } else if ( prefix ) {
+                // add prefix without html for least change of the priority level
+                selector = `${ prefix } ${ selector }`
             }
             return selector
         } )

--- a/test.js
+++ b/test.js
@@ -6,25 +6,50 @@ const run = ( t, input, output, opts = {} ) =>
 
     postcss( [ plugin( opts ) ] ).process( input )
         .then( result => {
-            t.deepEqual( result.css.replace( /\s+/g, ' ' ), output )
+            t.deepEqual( result.css.replace( /\s+/g, ' ' ), output.replace( /\s+/g, ' ' ) )
             t.deepEqual( result.warnings().length, 0 )
         } )
 
 
-test( 'Added html[dir] prefix to symmetric rules', t => run( t,
+test( 'Should NOT add [dir] prefix to symmetric rules', t => run( t,
+    'a { font-size: 1em }',
+    'a { font-size: 1em }'
+) )
+
+test( 'Should ONLY create LTR & RTL rules to asymmetric rules', t => run( t,
+    'a { font-size: 1em; text-align: left }',
+    'a { font-size: 1em } ' +
+    '[dir="ltr"] a { text-align: left } ' +
+    '[dir="rtl"] a { text-align: right }'
+) )
+
+test( 'Should add [dir] prefix to symmetric rules with direction related declarations', t => run( t,
     'a { text-align: center }',
-    'html[dir] a { text-align: center }'
+    '[dir] a { text-align: center }'
+) )
+
+test( 'Should add [dir] prefix to symmetric rules with direction related declarations (2)', t => run( t,
+    'a { font-size: 1em; text-align: center }',
+    'a { font-size: 1em } ' +
+    '[dir] a { text-align: center }'
+) )
+
+test( 'Should add [dir] prefix to symmetric rules with direction related declarations (3)', t => run( t,
+    'a { text-align: left } ' +
+    'a { text-align: center }',
+    '[dir="ltr"] a { text-align: left } ' +
+    '[dir="rtl"] a { text-align: right } ' +
+    '[dir] a { text-align: center }'
 ) )
 
 test( 'Creates both LTR & RTL rules for asymmetric declarations', t => run( t,
     'a { text-align: left }',
-    'html[dir="ltr"] a { text-align: left } ' +
-    'html[dir="rtl"] a { text-align: right }'
+    '[dir="ltr"] a { text-align: left } ' +
+    '[dir="rtl"] a { text-align: right }'
 ) )
 
 test( 'Removes original rule without symmetric declarations', t => run( t,
     'a { text-align: left }',
-    'html[dir="ltr"] a { text-align: left } ' +
-    'html[dir="rtl"] a { text-align: right }'
+    '[dir="ltr"] a { text-align: left } ' +
+    '[dir="rtl"] a { text-align: right }'
 ) )
-


### PR DESCRIPTION
- Omit `html` selector;
- Only and `[dir]` to rules which have special declarations.