### PR TITLE
fix: overrides for rtl:ignore

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,19 +29,16 @@ module.exports = postcss.plugin( 'postcss-rtl', ( options ) => css => {
         let rtlDecls = []
         let dirDecls = []
 
+        const prevNode = rule.prev()
+        if (prevNode && prevNode.type === 'comment' && prevNode.text === 'rtl:ignore') {
+            // we were told to ignore the next directive
+            prevNode.remove()
+            return
+        }
+
         if ( isSelectorHasDir( rule.selector, options ) ) return
         if ( isKeyframeRule( rule.parent ) ) return
 
-        let commentNode
-        if (
-            rule.parent &&
-            rule.parent.nodes &&
-            ( commentNode = rule.parent.nodes[0] ).type === 'comment' &&
-            commentNode.text === 'rtl:ignore' ) {
-                // we were told to ignore the next directive
-            rule.parent.removeChild( commentNode )
-            return
-        }
         rule.walkDecls( decl => {
             const rtl = rtlifyDecl( decl, keyframes )
 

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 import postcss from 'postcss'
 import test    from 'ava'
-import plugin from './lib'
+import plugin from './src'
 
 const run = ( t, input, output, opts = {} ) =>
 
@@ -114,11 +114,17 @@ test ( 'Should ignore declarations prefixed with /* rtl:ignore */', t => run( t,
     '.test { margin-left:0; padding-left:0 }',
 ) )
 
-test ( ' /* rtl:ignore */: Should leave other selectors alone', t => run( t,
+test ( '/* rtl:ignore */: Should leave other selectors alone', t => run( t,
     '/* rtl:ignore */ .test { margin-left:0 } ' +
     '.rtled { margin-left:0; padding-left:0 }',
 
     '.test { margin-left:0 } ' +
     '[dir=ltr] .rtled { margin-left:0; padding-left:0 } ' +
     '[dir=rtl] .rtled { margin-right:0; padding-right:0 }',
+) )
+
+
+test ( '/* rtl:ignore */: should understand overrides', t => run( t,
+    '.x { left: 0 } /* rtl:ignore */ .x { direction: ltr }',
+    '[dir=ltr] .x { left: 0 } [dir=rtl] .x { right: 0 } .x { direction: ltr }'
 ) )


### PR DESCRIPTION
When doing #16 I did not take into account that there could be overrides like this:

```css
.x { left: 0 }
/* rtl:ignore */ .x { direction: ltr }
```

where one declaration of a rule (here `left`) would need to be RTLified, but another is supposed to be ignored (here `direction`).

Sorry about that!

PTAL @vkalinichev 