### PR TITLE
fix: comments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,8 +48,8 @@ module.exports = postcss.plugin( 'postcss-rtl', ( options ) => css => {
             }
             if ( isRtlComment ) {
                 node.remove()
-                return
             }
+            return
         } else if ( node.type !== 'rule' ) {
             return
         }

--- a/src/index.js
+++ b/src/index.js
@@ -31,26 +31,22 @@ module.exports = postcss.plugin( 'postcss-rtl', ( options ) => css => {
         let dirDecls = []
 
         if ( node.type === 'comment' ) {
-            let isRtlComment = false
             switch ( node.text ) {
                 case 'rtl:ignore':
-                    isRtlComment = true
                     skip = 1
+                    node.remove()
                     break
                 case 'rtl:begin:ignore':
-                    isRtlComment = true
                     skip = Infinity
+                    node.remove()
                     break
                 case 'rtl:end:ignore':
-                    isRtlComment = true
                     skip = 0
+                    node.remove()
                     break
             }
-            if ( isRtlComment ) {
-                node.remove()
-            }
-            return
-        } else if ( node.type !== 'rule' ) {
+        }
+        if ( node.type !== 'rule' ) {
             return
         }
         if ( skip-- > 0 ) return

--- a/test.js
+++ b/test.js
@@ -156,3 +156,8 @@ test ( '/* rtl:ignore */ can be used inside /* rtl:begin:ignore */ and /* rtl:en
     `.foo { padding-left: 0 }
 .bar { direction: ltr }`
 ) )
+
+test ( 'that it ignores normal comments ', t => run( t,
+    '/* some comment */ .foo { padding-left: 0 }',
+    '/* some comment */ [dir=ltr] .foo { padding-left: 0 } [dir=rtl] .foo { padding-right: 0 }'
+) )


### PR DESCRIPTION
#18 introduced a regression for standard comments, where postcss-rtl would throw with:
```
Error: rule.walkDecls is not a function
```
this PR contains a fix for it.