### PR TITLE
fix: ignore inside begin/end does not only ignore next selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "prepare": "npm run build && npm test",
     "start": "gulp",
     "lint": " eslint src/*.js",
-    "test": "ava"
+    "test": "ava",
+    "test:watch": "ava --watch"
   },
   "engines": {
     "node": ">=0.12"

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ module.exports = postcss.plugin( 'postcss-rtl', ( options ) => css => {
         if ( node.type === 'comment' ) {
             switch ( node.text ) {
                 case 'rtl:ignore':
-                    skip = 1
+                    skip = Math.max(skip, 1)
                     node.remove()
                     break
                 case 'rtl:begin:ignore':

--- a/test.js
+++ b/test.js
@@ -152,9 +152,11 @@ test ( '/* rtl:ignore */ can be used inside /* rtl:begin:ignore */ and /* rtl:en
 .foo { padding-left: 0 }
 /* rtl:ignore */
 .bar { direction: ltr }
+.baz { left: 0 }
 /* rtl:end:ignore */`,
     `.foo { padding-left: 0 }
-.bar { direction: ltr }`
+.bar { direction: ltr }
+.baz { left: 0 }`
 ) )
 
 test ( 'that it ignores normal comments ', t => run( t,


### PR DESCRIPTION
Before, an `rtl:ignore` inside a `rtl:begin:ignore` and `rtl:end:ignore` would kick postcss-rtl back to only ignoring the next selector. This PR contains a fix for that.

references #18 

cc @chrisdoble