### PR TITLE
Remove use of deprecated moveTo function in PostCSS.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,11 @@ module.exports = postcss.plugin( 'postcss-rtl', ( options ) => css => {
             let ltrDirRule
             getDirRule( rule, 'rtl', options ).append( rtlDecls )
             ltrDirRule = getDirRule( rule, 'ltr', options )
-            ltrDecls.forEach( _decl => ltrDirRule.append( _decl ) )
+            ltrDecls.forEach( _decl => {
+                _decl.cleanRaws( _decl.root() === ltrDirRule.root() )
+                rule.removeChild( _decl )
+                ltrDirRule.append( _decl )
+            })
         }
 
         if ( dirDecls.length ) {

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ module.exports = postcss.plugin( 'postcss-rtl', ( options ) => css => {
             let ltrDirRule
             getDirRule( rule, 'rtl', options ).append( rtlDecls )
             ltrDirRule = getDirRule( rule, 'ltr', options )
-            ltrDecls.forEach( _decl => _decl.moveTo( ltrDirRule ) )
+            ltrDecls.forEach( _decl => ltrDirRule.append( _decl ) )
         }
 
         if ( dirDecls.length ) {


### PR DESCRIPTION
https://github.com/postcss/postcss/blob/29a51b9c82bdf11f226e0d4196d18865d4bd10de/lib/node.es6#L242
Node#moveTo was deprecated. Use Container#append.