### PR TITLE
Support rtl ignore on keyframes-animation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,8 +13,48 @@ module.exports = postcss.plugin( 'postcss-rtl', ( options ) => css => {
 
     options = validateOptions( options )
 
+    const handleAnimation = ( removeComments = false ) => {
+        let isIgnored = false
+        let continuousIgnore = false
+
+        return ( node ) => {
+            if ( node.type === 'comment' ) {
+                switch ( node.text ) {
+                    case 'rtl:ignore':
+                        isIgnored = true
+                        continuousIgnore = continuousIgnore || false
+                        removeComments && node.remove()
+                        break
+                    case 'rtl:begin:ignore':
+                        isIgnored = true
+                        continuousIgnore = true
+                        removeComments && node.remove()
+                        break
+                    case 'rtl:end:ignore':
+                        isIgnored = false
+                        continuousIgnore = false
+                        removeComments && node.remove()
+                        break
+                }
+                return true
+            }
+            if ( !continuousIgnore && isIgnored ) {
+                isIgnored = false
+                return true
+            }
+            return isIgnored
+        }
+    }
+
+    const isKeyframeIgnored = handleAnimation()
+    const isRuleIgnored = handleAnimation( true )
+
     // collect @keyframes
-    css.walkAtRules( rule => {
+    css.walk( rule => {
+
+        if ( isKeyframeIgnored( rule ) ) return
+        if ( rule.type !== 'atrule' ) return
+
         if ( !isKeyframeRule( rule ) ) return
         if ( isKeyframeAlreadyProcessed( rule ) ) return
         if ( isKeyframeSymmetric( rule ) ) return
@@ -23,33 +63,17 @@ module.exports = postcss.plugin( 'postcss-rtl', ( options ) => css => {
         rtlifyKeyframe( rule )
     } )
 
-    let skip = 0
     // Simple rules (includes rules inside @media-queries)
     css.walk( node => {
         let ltrDecls = []
         let rtlDecls = []
         let dirDecls = []
 
-        if ( node.type === 'comment' ) {
-            switch ( node.text ) {
-                case 'rtl:ignore':
-                    skip = Math.max(skip, 1)
-                    node.remove()
-                    break
-                case 'rtl:begin:ignore':
-                    skip = Infinity
-                    node.remove()
-                    break
-                case 'rtl:end:ignore':
-                    skip = 0
-                    node.remove()
-                    break
-            }
-        }
+        if ( isRuleIgnored( node ) ) return
+
         if ( node.type !== 'rule' ) {
             return
         }
-        if ( skip-- > 0 ) return
         const rule = node
 
         if ( isSelectorHasDir( rule.selector, options ) ) return

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ module.exports = postcss.plugin( 'postcss-rtl', ( options ) => css => {
 
     options = validateOptions( options )
 
-    const handleAnimation = ( removeComments = false ) => {
+    const handleIgnores = ( removeComments = false ) => {
         let isIgnored = false
         let continuousIgnore = false
 
@@ -46,8 +46,8 @@ module.exports = postcss.plugin( 'postcss-rtl', ( options ) => css => {
         }
     }
 
-    const isKeyframeIgnored = handleAnimation()
-    const isRuleIgnored = handleAnimation( true )
+    const isKeyframeIgnored = handleIgnores()
+    const isRuleIgnored = handleIgnores( true )
 
     // collect @keyframes
     css.walk( rule => {

--- a/test.js
+++ b/test.js
@@ -163,3 +163,26 @@ test ( 'that it ignores normal comments ', t => run( t,
     '/* some comment */ .foo { padding-left: 0 }',
     '/* some comment */ [dir=ltr] .foo { padding-left: 0 } [dir=rtl] .foo { padding-right: 0 }'
 ) )
+
+test( 'Should add direction to flippable keyframes-animations', t => run( t,
+    '@keyframes bar { 100% { transform: rotate(360deg); } }',
+    '@keyframes bar-ltr { 100% { transform: rotate(360deg); } } ' +
+    '@keyframes bar-rtl { 100% { transform: rotate(-360deg); } }'
+) )
+
+test( 'Should ignore keyframes-animation prefixed with /* rtl:ignore */', t => run( t,
+    '/* rtl:ignore */ @keyframes bar { 100% { transform: rotate(360deg); } }',
+    '@keyframes bar { 100% { transform: rotate(360deg); } }'
+) )
+
+test( '/* rtl:begin:ignore */ starts ignore mode for both keyframes and rules', t => run( t,
+    '/* rtl:begin:ignore */ @keyframes bar { 100% { transform: rotate(360deg); } } .foo { left: 5px }',
+    '@keyframes bar { 100% { transform: rotate(360deg); } } .foo { left: 5px }'
+) )
+
+test( '/* rtl:end:ignore */ stops ignore mode for keyframes', t => run( t,
+    '/* rtl:begin:ignore */ @keyframes bar { 100% { transform: rotate(360deg); } } /* rtl:end:ignore */' +
+    '.foo { left: 5px }',
+    '@keyframes bar { 100% { transform: rotate(360deg); } }' +
+    '[dir=ltr] .foo { left: 5px; }[dir=rtl] .foo { right: 5px; }'
+) )


### PR DESCRIPTION
Currently there is no way to prevent a flippable keyframes-animation from being converted from 
```
@keyframes foo { 100% { transform: rotate(360deg)
to
@keyframes foo-ltr { 100% { transform: rotate(360deg)
and 
@keyframes foo-rtl { 100% { transform: rotate(360deg)
```

**After this change**

```
/* rtl:ignore */
@keyframes foo { 100% { transform: rotate(360deg)
and 
/* rtl:begin:ignore */
@keyframes foo { 100% { transform: rotate(360deg)
...
/* rtl:end:ignore */ 
will prevent conversion to -ltr and -rtl 
```


