### PR TITLE
Allow passing `onlyDirection` as falsy value

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -13,7 +13,7 @@ const validateOptions = (options = {}) => {
     console.warn('Incorrect **addPrefixToSelector option. Must be a function')
   }
 
-  if (onlyDirection !== undefined && typeof onlyDirection !== 'string') {
+  if (onlyDirection && typeof onlyDirection !== 'string') {
     fixedOptions.onlyDirection = defaultOptions.onlyDirection
     console.warn('Incorrect onlyDirection option. Allowed values: ltr, rtl')
   }


### PR DESCRIPTION
Currently the default option for `onlyDirection` (false) causes a warning to be raised if no value is explicitly passed. This occurs for subsequent imports of the `postcss-rtl` library as the `options` argument get mutated during the module export (https://github.com/vkalinichev/postcss-rtl/blob/master/src/index.js#L14):
```js
  options = validateOptions(options)
```

Might also be worth changing the above to assign to a new variable so the `options` argument passed isn't mutated