### PR TITLE
Skip variable when using rtlcss

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -1,5 +1,17 @@
 const rtlcss = require('rtlcss')
 const {isSelectorHasDir, addDirToSelectors} = require('./selectors')
+const rtlcssOptions = {
+  name: 'Skip variables',
+  priority: 1,
+  directives: { control: {}, value: [] },
+  processors: [
+    {
+      name: '--',
+      expr: /^--/im,
+      action: (prop, value) => ({ prop, value })
+    }
+  ]
+}
 
 const getDirRule = (rule, dir, options) => {
   const next = rule.next()
@@ -22,7 +34,7 @@ const setRuleDir = (rule, dir, options) => {
 }
 
 const rtlifyRule = rule => {
-  const rtlResult = rtlcss.process(rule, null, null)
+  const rtlResult = rtlcss.process(rule, null, rtlcssOptions)
 
   return (rtlResult !== rule.toString()) ? rtlResult : false
 }


### PR DESCRIPTION
When not passing options to rtlcss, it currently parses
```css
:root {
  --brightest: #fff;
}

body {
  background: var(--brightest);
}
```

into

```css
:root {
  --bleftest: #fff;
}

body {
  background: var(--brightest);
}
```

With this commit, rtlcss skips variables.