### PR TITLE
Add option to generate LTR css for RTL styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,9 @@ gulp.src( 'style.css' )
     * `attribute` (by default, recommended): `.foo` => `[dir=rtl] .foo`
     * `class` (useful for IE6): `.foo` => `.dir-rtl .foo`
     
-* `removeComments` (default: `true`): remove `rtl:*` comments after process them
+* `removeComments` (default: `true`): remove `rtl:*` comments after process them   
+
+* `fromRTL`: assume all styles are written in RTL direction and generate corresponding LTR styles for them  
 
 ## Thanks
 Great thanks to projects:

--- a/src/index.js
+++ b/src/index.js
@@ -136,7 +136,7 @@ module.exports = postcss.plugin('postcss-rtl', options => (css) => {
     if (isKeyframeRule(rule.parent)) return
 
     rule.walkDecls((decl) => {
-      // Is there a  value directive?
+      // Is there a value directive?
       if (handleValueDirectives(decl, ltrDecls, rtlDecls)) return
 
       const rtl = rtlifyDecl(decl, keyframes)

--- a/src/options.js
+++ b/src/options.js
@@ -2,12 +2,14 @@ const defaultOptions = {
   addPrefixToSelector: false, // customized function for joining prefix and selector
   prefixType: 'attribute', // type of dir-prefix: attribute [dir] or class .dir,
   onlyDirection: false, // "ltr", "rtl": compile only one-direction version
+  fromRTL: false, // assume styles are written in rtl initially
   removeComments: true, // remove comments after process them
 }
 
 const validateOptions = (options = {}) => {
   const {
-    addPrefixToSelector, prefixType, onlyDirection, removeComments,
+    addPrefixToSelector, prefixType, onlyDirection,
+    removeComments, fromRTL,
   } = options
   const fixedOptions = {}
 
@@ -34,6 +36,11 @@ const validateOptions = (options = {}) => {
   if (removeComments && typeof removeComments !== 'boolean') {
     fixedOptions.removeComments = defaultOptions.removeComments
     console.warn('Incorrect removeComments option. Must be a boolean')
+  }
+
+  if (fromRTL && typeof fromRTL !== 'boolean') {
+    fixedOptions.removeComments = defaultOptions.removeComments
+    console.warn('Incorrect fromRTL option. Must be a boolean')
   }
 
   return Object.assign({},

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -8,6 +8,18 @@ const isRootSelector = (selector = '') => !!selector.match(/:root/)
 
 const addDirToSelectors = (selectors = '', dir, options = {}) => {
   const {addPrefixToSelector, prefixType} = options
+  // we swap direction prefixes if we are converting rtl styles to ltr
+  if (options.fromRTL) {
+    switch (dir) {
+      case 'rtl':
+        dir = 'ltr'
+        break
+      case 'ltr':
+        dir = 'rtl'
+        break
+      default:
+    }
+  }
   const prefix = prefixes[prefixType].prefixes[dir]
   if (!prefix) return selectors
 


### PR DESCRIPTION
Hi, thank you for your awesome and stable plugin.  
This PR adds an important feature for applications that are written in RTL direction initially.  
By setting the `fromRTL` option to true, we assume that all the styles has written in RTL and we add `[dir=ltr]` for styles generated by `rtlcss`.  
Now developers can initially develop their user interface in RTL and auto generate LTR styles. 😃   
Thanks again. Your plugin makes using `rtlcss` 100 times easier.