### PR TITLE
Added support for a custom prefix (other than 'dir')

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 npm-debug.log
 lib/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -273,12 +273,17 @@ gulp.src( 'style.css' )
         return `${prefix} > ${selector}` // Make selectors like [dir=rtl] > .selector
     }
     ```
+  **note:** the returned string _must_ include `prefix` to avoid an infinite recursion
 
 * `onlyDirection`: generate only one-direction version: `ltr` or `rtl`
 
 * `prefixType`: Switches between adding attributes and classes. Optional: 
     * `attribute` (by default, recommended): `.foo` => `[dir=rtl] .foo`
     * `class` (useful for IE6): `.foo` => `.dir-rtl .foo`
+    
+* `prefix`: Uses a custom string, instead of 'dir', for the added attribute and class selectors
+    * e.g. `'data-my-custom-dir'` (for attribute prefixType): `.foo` => `[data-my-custom-dir=rtl] .foo`
+    * e.g. `'my-custom-dir'` (for class prefixType): `.foo` => `.my-custom-dir-rtl .foo`
     
 * `removeComments` (default: `true`): remove `rtl:*` comments after process them   
 

--- a/src/options.js
+++ b/src/options.js
@@ -1,6 +1,7 @@
 const defaultOptions = {
   addPrefixToSelector: false, // customized function for joining prefix and selector
   prefixType: 'attribute', // type of dir-prefix: attribute [dir] or class .dir,
+  prefix: 'dir', // string to use as prefix (e.g. dir, my-special-dir)
   onlyDirection: false, // "ltr", "rtl": compile only one-direction version
   fromRTL: false, // assume styles are written in rtl initially
   removeComments: true, // remove comments after process them
@@ -9,8 +10,8 @@ const defaultOptions = {
 /* eslint-disable no-console */
 const validateOptions = (options = {}) => {
   const {
-    addPrefixToSelector, prefixType, onlyDirection,
-    removeComments, fromRTL,
+    addPrefixToSelector, prefixType, prefix,
+    onlyDirection, removeComments, fromRTL,
   } = options;
   const fixedOptions = {};
 
@@ -32,6 +33,10 @@ const validateOptions = (options = {}) => {
   if (prefixType && ['attribute', 'class'].indexOf(prefixType) < 0) {
     fixedOptions.prefixType = defaultOptions.prefixType;
     console.warn('Incorrect prefixType option. Allowed values: attribute, class');
+  }
+
+  if (typeof prefix === 'string' && prefix.length < 1) {
+    console.warn('Incorrect prefix: must not be empty');
   }
 
   if (removeComments && typeof removeComments !== 'boolean') {

--- a/src/prefixes-config.js
+++ b/src/prefixes-config.js
@@ -1,18 +1,18 @@
-module.exports = {
+module.exports = ({prefix}) => ({
   attribute: {
     prefixes: {
-      ltr: '[dir=ltr]',
-      rtl: '[dir=rtl]',
-      dir: '[dir]',
+      ltr: `[${prefix}=ltr]`,
+      rtl: `[${prefix}=rtl]`,
+      dir: `[${prefix}]`,
     },
-    regex: /\[dir(=(\w+|"\w+"))?\]/,
+    regex: new RegExp(`\\[${prefix}(=(\\w+|"\\w+"))?\\]`),
   },
   class: {
     prefixes: {
-      ltr: '.dir-ltr',
-      rtl: '.dir-rtl',
-      dir: '.dir',
+      ltr: `.${prefix}-ltr`,
+      rtl: `.${prefix}-rtl`,
+      dir: `.${prefix}`,
     },
-    regex: /\.dir(-\w+)?/,
+    regex: new RegExp(`\\.${prefix}(-\\w+)?`),
   },
-};
+});

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -1,6 +1,6 @@
-const prefixes = require('./prefixes-config');
+const generatePrefixes = require('./prefixes-config');
 
-const isSelectorHasDir = (selector = '', {prefixType}) => !!selector.match(prefixes[prefixType].regex);
+const isSelectorHasDir = (selector = '', options) => !!selector.match(generatePrefixes(options)[options.prefixType].regex);
 
 const isHtmlSelector = (selector = '') => !!selector.match(/^html/);
 
@@ -20,7 +20,7 @@ const addDirToSelectors = (selectors = '', dir, options = {}) => {
       default:
     }
   }
-  const prefix = prefixes[prefixType].prefixes[dir];
+  const prefix = generatePrefixes(options)[prefixType].prefixes[dir];
   if (!prefix) return selectors;
 
   return selectors

--- a/src/test.js
+++ b/src/test.js
@@ -252,3 +252,16 @@ test('Should keep comments', t => run(t,
   '/* rtl:ignore */ a { text-align: left }',
   '/* rtl:ignore */ a { text-align: left }',
   {removeComments: false}));
+
+test('Should respect custom prefix (attribute)', t => run(t,
+  'a { text-align: left }',
+  '[custom-dir-prefix=ltr] a { text-align: left }'
+  + '[custom-dir-prefix=rtl] a { text-align: right }',
+  {prefix: 'custom-dir-prefix'}));
+
+test('Should respect custom prefix (class)', t => run(t,
+  'a { text-align: left }',
+  '.custom-dir-prefix-ltr a { text-align: left }'
+  + '.custom-dir-prefix-rtl a { text-align: right }',
+  {prefix: 'custom-dir-prefix', prefixType: 'class'}));
+


### PR DESCRIPTION
This allows the consumer to use custom attributes/classes to mark direction. Example: `[data-my-custom-dir=rtl]` instead of `[dir=rtl]` or `.my-custom-dir-rtl` instead of `.dir-rtl`.

**Usage**
`prefix` is provided as a plugin option (default: 'dir'):
```
{
    require('postcss-rtl')({
        prefix: 'data-custom-dir'
    })
}
```

**Motivation**
It's sometimes useful to 'namespace' the direction indicator selector to ensure uniqueness and predictability.
For example, the project may be a widget, loaded on 3rd party pages. The `dir` attribute may be missing or duplicated:
```
<html dir="ltr">
  <body>
       <main dir="rtl">
          ...
       </main>
    </body>
</html>
```
in which case both `[dir=ltr] ...` and `[dir=rtl] ...` apply, causing e.g. both `margin-left` and `margin-right`.